### PR TITLE
feat: add SVGR sync workflow to regenerate and verify icon components

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,52 +6,7 @@ on:
       - "main"
 
 jobs:
-  svgr-sync:
-    name: Regenerate icon components
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      pushed: ${{ steps.sync.outputs.pushed }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate icon components from SVGs
-        run: pnpm run svgr
-
-      - name: Commit and push if out of sync
-        id: sync
-        run: |
-          if git diff --exit-code src; then
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            echo "Generated components already in sync."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src
-          git commit -m "chore: regenerate icon components from SVGs"
-          git push
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
-          echo "Regenerated src/ and pushed to main. Release will run on the next workflow trigger."
-
   release:
-    needs: svgr-sync
-    if: needs.svgr-sync.outputs.pushed != 'true'
     uses: signoz/primus.workflows/.github/workflows/js-release.yaml@js-release
     secrets: inherit
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,52 @@ on:
       - "main"
 
 jobs:
+  svgr-sync:
+    name: Regenerate icon components
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      pushed: ${{ steps.sync.outputs.pushed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate icon components from SVGs
+        run: pnpm run svgr
+
+      - name: Commit and push if out of sync
+        id: sync
+        run: |
+          if git diff --exit-code src; then
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            echo "Generated components already in sync."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src
+          git commit -m "chore: regenerate icon components from SVGs"
+          git push
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+          echo "Regenerated src/ and pushed to main. Release will run on the next workflow trigger."
+
   release:
+    needs: svgr-sync
+    if: needs.svgr-sync.outputs.pushed != 'true'
     uses: signoz/primus.workflows/.github/workflows/js-release.yaml@js-release
     secrets: inherit
     with:

--- a/.github/workflows/svgr-sync.yml
+++ b/.github/workflows/svgr-sync.yml
@@ -1,0 +1,65 @@
+name: SVGR sync
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "assets/**"
+      - "svgr-template.js"
+      - "index-template.cjs"
+      - "package.json"
+  push:
+    branches: ["main"]
+    paths:
+      - "assets/**"
+      - "svgr-template.js"
+      - "index-template.cjs"
+      - "package.json"
+
+jobs:
+  svgr-sync:
+    name: SVGR – regenerate or verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate icon components from SVGs
+        run: pnpm run svgr
+
+      - name: Sync generated components
+        run: |
+          if git diff --exit-code src; then
+            echo "Generated components are in sync."
+            exit 0
+          fi
+          # On PRs: commit and push so the branch stays in sync
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add src
+            git commit -m "chore: regenerate icon components from SVGs [skip ci]"
+            git push
+            echo "Regenerated src/ and pushed to the branch."
+          else
+            # Push to main: require author to have run svgr (do not auto-commit to main)
+            echo "::error::Generated icon components are out of sync with assets/*.svg"
+            echo "Run \`pnpm run svgr\` and commit the updated src/ (or merge a PR where CI already did it)."
+            git diff --stat src
+            exit 1
+          fi

--- a/.github/workflows/svgr-sync.yml
+++ b/.github/workflows/svgr-sync.yml
@@ -8,24 +8,13 @@ on:
       - "svgr-template.js"
       - "index-template.cjs"
       - "package.json"
-  push:
-    branches: ["main"]
-    paths:
-      - "assets/**"
-      - "svgr-template.js"
-      - "index-template.cjs"
-      - "package.json"
 
 jobs:
-  svgr-sync:
-    name: SVGR – regenerate or verify
+  svgr-check:
+    name: SVGR in sync
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -42,24 +31,14 @@ jobs:
       - name: Generate icon components from SVGs
         run: pnpm run svgr
 
-      - name: Sync generated components
+      - name: Check components in sync with assets
         run: |
-          if git diff --exit-code src; then
-            echo "Generated components are in sync."
-            exit 0
-          fi
-          # On PRs: commit and push so the branch stays in sync
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add src
-            git commit -m "chore: regenerate icon components from SVGs [skip ci]"
-            git push
-            echo "Regenerated src/ and pushed to the branch."
-          else
-            # Push to main: require author to have run svgr (do not auto-commit to main)
-            echo "::error::Generated icon components are out of sync with assets/*.svg"
-            echo "Run \`pnpm run svgr\` and commit the updated src/ (or merge a PR where CI already did it)."
+          if ! git diff --exit-code src; then
+            echo "::error::Generated icon components are out of sync with assets."
+            echo ""
+            echo "Run the following locally, then commit and push:"
+            echo "  pnpm run svgr"
+            echo ""
             git diff --stat src
             exit 1
           fi


### PR DESCRIPTION
## Summary

Add a GitHub Actions check so that icon components stay in sync with `assets/*.svg`. When a PR touches assets or SVGR config, the workflow runs SVGR and fails if generated `src/` doesn’t match, asking the author to run `pnpm run svgr` and push. No auto-commits; release workflow is unchanged.

## Changes

### New: `.github/workflows/svgr-sync.yml`
- **Triggers:** Pull requests to `main` when `assets/**`, `svgr-template.js`, `index-template.cjs`, or `package.json` change.
- **Behavior:** Installs deps, runs `pnpm run svgr`, then `git diff --exit-code src`.
- **If out of sync:** Fails the check and prints a message asking the user to run `pnpm run svgr` locally, then commit and push.
- **If in sync:** Check passes.

### Unchanged: `release.yml`
- No SVGR checks; release runs as before. Enforcement is at the PR level via branch protection (require “SVGR in sync” for `main`).

## Result
- PRs that add or change SVGs must have regenerated `src/` committed or the check fails.
- Authors get clear instructions to run `pnpm run svgr` and push instead of the workflow auto-committing.
- Optional: in branch protection for `main`, require the “SVGR in sync” status check so merges are blocked until the check passes.