### PR TITLE
fix: release action for icons

### DIFF
--- a/.changeset/yellow-suns-brake.md
+++ b/.changeset/yellow-suns-brake.md
@@ -2,4 +2,6 @@
 "@signozhq/icons": minor
 ---
 
-Signoz icons package update
+- Add `forwardRef` support to all icon components for better ref forwarding compatibility
+- Fix icon colors not applying correctly when `color` prop is passed
+- Add new icons: `Binoculars`, `Calendar1`, `DecimalsArrowRight`, `SolidGoogle`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: signoz/primus.workflows/.github/workflows/js-release.yaml@js-release
     secrets: inherit
     with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
  "name": "@signozhq/icons",
  "author": "SigNoz",
- "version": "0.3.0",
+ "version": "0.4.0",
  "description": "SVG-based React icon components",
  "keywords": [
   "React",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
  "name": "@signozhq/icons",
  "author": "SigNoz",
- "version": "0.1.0",
+ "version": "0.3.0",
  "description": "SVG-based React icon components",
  "keywords": [
   "React",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
  "name": "@signozhq/icons",
  "author": "SigNoz",
- "version": "0.4.0",
+ "version": "0.3.0",
  "description": "SVG-based React icon components",
  "keywords": [
   "React",


### PR DESCRIPTION
current icon github release seems to be broken. 

this pr should fix this issue 

<img width="976" height="667" alt="image" src="https://github.com/user-attachments/assets/9cfe29c0-ab51-4705-be5e-609428186ed0" />
